### PR TITLE
Use table to represent results

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,68 +7,26 @@ Including crystal-lang for comparison
 
 ## Natively compiled, statically typed
 
-### C - 6.999 Seconds
-```bash
-gcc -o fib fib.c
-time ./fib
-```
-
-### C++ - 7.166 Seconds
-```bash
-g++ -o fib fib.cpp
-time ./fib
-```
-
-### Go - 6.703 Seconds
-```bash
-go build fib.go
-time ./fib
-```
-
-### Crystal - 3.857 Seconds
-```bash
-crystal build fib.cr --release
-time ./fib
-```
+| Language  | Time, s | Compile                          | Run          |
+|-----------|---------|----------------------------------|--------------|
+| C         | 6.999   | `gcc -o fib fib.c`               | `time ./fib` |
+| C++       | 7.166   | `g++ -o fib fib.ccp`             | `time ./fib` |
+| Go        | 6.703   | `go build fib.go`                | `time ./fib` |
+|**Crystal**|**3.857**| `crystal build fib.cr --release` | `time ./fib` |
 
 ## VM bytecode, statically typed
 
-### C# using DotNet - 43 Seconds 
-```bash
-dotnet restore
-time dotnet run
-```
-
-### C# using Mono - 7.166 Seconds
-```bash
-mcs fib.cs
-time mono fib.exe
-```
-
-### Java - 4.672 Seconds
-```bash
-javac Fib.java
-time java Fib
-```
+| Language      | Time, s | Compile          | Run                 |
+|---------------|---------|------------------|---------------------|
+| C#            | 43      | `dotnet restore` | `time dotnet run`   |
+| C# using Mono | 7.166   | `mcs fib.cs`     | `time mono fib.exe` |
+| Java          | 4.672   | `javac Fib.java` | `time java Fib`     |
 
 ## Interpreted, dynamically typed
 
-### Node - 12.76 Seconds
-```bash
-time node fib.js
-```
-
-### Ruby - 2 Minutes 4 Seconds
-```bash
-time ruby fib.rb
-```
-
-### Python - 5 Minutes 44 seconds
-```bash
-time python fib.py
-```
-
-### PHP - 6 Minutes 2 Seconds
-```bash
-time php fib.php
-```
+| Language | Time                 | Run                |
+|----------|----------------------|--------------------|
+| Node     | 12.76 Seconds        | `time node fib.js` |
+| Ruby     | 2 Minutes 4 Seconds  | `time ruby fb.rb`  |
+| Python   | 5 Minutes 44 Seconds | `time python fb.rb`|
+| PHP      | 6 Minutes 2 Seconds  | `time php fb.php`  |


### PR DESCRIPTION
Now it is much easier to investigate results:

## Natively compiled, statically typed

| Language  | Time, s | Compile                          | Run          |
|-----------|---------|----------------------------------|--------------|
| C         | 6.999   | `gcc -o fib fib.c`               | `time ./fib` |
| C++       | 7.166   | `g++ -o fib fib.ccp`             | `time ./fib` |
| Go        | 6.703   | `go build fib.go`                | `time ./fib` |
|**Crystal**|**3.857**| `crystal build fib.cr --release` | `time ./fib` |

## VM bytecode, statically typed

| Language      | Time, s | Compile          | Run                 |
|---------------|---------|------------------|---------------------|
| C#            | 43      | `dotnet restore` | `time dotnet run`   |
| C# using Mono | 7.166   | `mcs fib.cs`     | `time mono fib.exe` |
| Java          | 4.672   | `javac Fib.java` | `time java Fib`     |

## Interpreted, dynamically typed

| Language | Time                 | Run                |
|----------|----------------------|--------------------|
| Node     | 12.76 Seconds        | `time node fib.js` |
| Ruby     | 2 Minutes 4 Seconds  | `time ruby fb.rb`  |
| Python   | 5 Minutes 44 Seconds | `time python fb.rb`|
| PHP      | 6 Minutes 2 Seconds  | `time php fb.php`  |
