### PR TITLE
Modify the csharp project file and add the compilation conditions.

### DIFF
--- a/Fib.cs
+++ b/Fib.cs
@@ -1,12 +1,46 @@
 using System;
+using System.Runtime.CompilerServices;
+public class Fib
+{
+#if !OPTIMISED
+#if TCO
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+    static uint fib(uint n)
+    {
+        if (n <= 1) return 1;
+        return fib(n - 1) + fib(n - 2);
+    }
 
-public class Fib {
-  static uint fib(uint n) {
-    if (n <= 1) return 1;
-    return fib(n - 1) + fib(n - 2);
-  }
+    public static void Main(string[] args)
+    {
+        Console.WriteLine(fib(46));
+    }
+#else
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    unsafe static uint fib(uint n, uint* cache)
+    {
+        if (n <= 1) return 1;
+        var a = &cache[n - 1];
+        var b = &cache[n - 2];
+        if (*a == 0)
+        {
+            *a = fib(n - 1, cache);
 
-  public static void Main(string[] args) {
-    Console.WriteLine(fib(46));
-  }
+        }
+        if (*b == 0)
+        {
+            *b = fib(n - 2, cache);
+        }
+        return *a + *b;
+    }
+    unsafe static void Main(string[] args)
+    {
+        uint[] array = new uint[46];
+        fixed (uint* cache = array)
+        {
+            Console.WriteLine(fib(46, cache));
+        }
+    }
+#endif
 }

--- a/fib.csproj
+++ b/fib.csproj
@@ -1,8 +1,20 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <Configurations>Debug;Release;Slow;WithTCO;Fast</Configurations>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Fast'">
+    <DefineConstants>TRACE;OPTIMISED</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='WithTCO'">
+    <DefineConstants>TRACE;TCO</DefineConstants>
+    <Optimize>true</Optimize>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
As @hex11 said:

> And these are what dotnet run do:

> restore (since dotnet core 2.0)
> build
> initialize runtime
> actually run 'fib'

So you should not do benchmark test by `dotnet run`.

I modified the .cs code and add three compile conditions (Slow & WithTCO & Fast).

### 1. Most slow
**The slowest one, but in Release mode**

build `dotnet build -c Release -o ./bin/slow`
run `time dotnet ./bin/slow/fib.dll`
result `11.122s`

### 2. WithTCO
**With TCO enable**

build `dotnet build -c WithTCO -o ./bin/withtco`
run `time dotnet ./bin/withtco/fib.dll`
result `7.844s`

### 3. Fast
**Optimized like Go (mem)**

build `dotnet build -c Fast -o ./bin/fast`
run `time dotnet ./bin/fast/fib.dll`
result `0.050s`

And I think you should use the 2nd result because java is enabled TCO by default.