### PR TITLE
Add Nim version with memoization

### DIFF
--- a/fib_mem.nim
+++ b/fib_mem.nim
@@ -1,0 +1,16 @@
+func fib(n: uint64, cache: var openArray[uint64]): uint64 =
+  if n <= 1:
+    return 1
+  var
+    a = cache[n.int - 1]
+    b = cache[n.int - 2]
+  if a == 0:
+    a = fib(n - 1, cache)
+    cache[n.int - 1] = a
+  if b == 0:
+    b = fib(n - 2, cache)
+    cache[n.int - 2] = b
+  return a + b
+
+var cache: array[46, uint64]
+echo fib(46, cache)


### PR DESCRIPTION
Simple enough, based on the JS version. Compile as with the regular Nim example:
```
nim cpp -d:release fib_mem.nim
```
Note, nim does not allow hyphens in file names, so I had to call in `fib_mem.nim` and not `fib-mem.nim` like the others.