### PR TITLE
Add Python 3 LRU cache version

### DIFF
--- a/fib_lru_cache.py
+++ b/fib_lru_cache.py
@@ -1,0 +1,10 @@
+# Python >= 3.2 needed.
+# https://docs.python.org/3/library/functools.html#functools.lru_cache
+from functools import lru_cache
+
+@lru_cache(None)
+def fib(n):
+  if n <= 1: return 1
+  return fib(n - 1) + fib(n - 2)
+
+print(fib(46))


### PR DESCRIPTION
The easy way to add memory cache for Python implementation is using the `functools.lru_cache` decorator with argument `maxsize=None`.
The `functools.lru_cache` decorator is added since Python 3.2 so Python >= 3.2 is needed.

In the same environment which described in another pull request: https://github.com/drujensen/fib/pull/18 , got:

```
$ time python fib_lru_cache.py 
2971215073

real	0m0.032s
user	0m0.026s
sys	0m0.006s
```

Python version:

```
$ python --version
Python 3.7.0
```