### PR TITLE
Add Cython benchmark code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ fib.dwarf
 nimcache
 fib-mem
 fib-constexpr
+fib.pyx.c

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Last benchmark was ran on September 25th, 2018
 | Swift    | 10.307  | `swiftc -O -g fib.swift`                     | `time ./fib` |
 | Go       | 10.600  | `go build fib.go`                            | `time ./fib` |
 | Haskell  |         | `ghc -O3 -o fib fib.hs`                      | `time ./fib` |
-| Cython   |         | `cython3 --embed -o fib.pyx.c fib.pyx &&`<br>`g++ -O3 -o fib fib.pyx.c $(pkg-config --cflags --libs python3)` | `time ./fib` |
+| Cython   |         | `cython3 --embed -o fib.pyx.c fib.pyx &&`<br>`gcc -O3 -o fib fib.pyx.c $(pkg-config --cflags --libs python3)` | `time ./fib` |
 
 
 NOTE: Swift and Go do not seem to use [Tail Call Optimization](https://en.wikipedia.org/wiki/Tail_call) so this may be why they are showing up as twice as slow.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Last benchmark was ran on September 25th, 2018
 | D        |  6.993  | `ldc2 -O3 -release -flto=full -of=fib fib.d` | `time ./fib` |
 | Swift    | 10.307  | `swiftc -O -g fib.swift`                     | `time ./fib` |
 | Go       | 10.600  | `go build fib.go`                            | `time ./fib` |
+| Cython   |         | `cython3 --embed -o fib.pyx.c fib.pyx &&`<br>`g++ -O3 -o fib fib.pyx.c -I/usr/include/python3.5m/ -lpython3.5m` | `time ./fib` |
+
 
 NOTE: Swift and Go do not seem to use [Tail Call Optimization](https://en.wikipedia.org/wiki/Tail_call) so this may be why they are showing up as twice as slow.
 Thank you [Ammrage](https://github.com/AmmRage) for pointing this out.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Last benchmark was ran on September 25th, 2018
 | D        |  6.993  | `ldc2 -O3 -release -flto=full -of=fib fib.d` | `time ./fib` |
 | Swift    | 10.307  | `swiftc -O -g fib.swift`                     | `time ./fib` |
 | Go       | 10.600  | `go build fib.go`                            | `time ./fib` |
-| Cython   |         | `cython3 --embed -o fib.pyx.c fib.pyx &&`<br>`g++ -O3 -o fib fib.pyx.c -I/usr/include/python3.5m/ -lpython3.5m` | `time ./fib` |
+| Cython   |         | `cython3 --embed -o fib.pyx.c fib.pyx &&`<br>`g++ -O3 -o fib fib.pyx.c $(pkg-config --cflags --libs python3)` | `time ./fib` |
 
 
 NOTE: Swift and Go do not seem to use [Tail Call Optimization](https://en.wikipedia.org/wiki/Tail_call) so this may be why they are showing up as twice as slow.

--- a/fib.pyx
+++ b/fib.pyx
@@ -1,6 +1,6 @@
 # Usage:
-#   cython3 --embed -o fib.c fib.pyx
-#   g++ -O3 -o fib fib.c -I/usr/include/python3.5m/ -lpython3.5m
+#   cython3 --embed -o fib.pyx.c fib.pyx
+#   g++ -O3 -o fib fib.pyx.c -I/usr/include/python3.5m/ -lpython3.5m
 #   time ./fib
 
 cdef long fib(long n):

--- a/fib.pyx
+++ b/fib.pyx
@@ -1,0 +1,10 @@
+# Usage:
+#   cython3 --embed -o fib.c fib.pyx
+#   g++ -O3 -o fib fib.c -I/usr/include/python3.5m/ -lpython3.5m
+#   time ./fib
+
+cdef long fib(long n):
+  if n <= 1: return 1
+  return fib(n - 1) + fib(n - 2)
+
+print(fib(46))

--- a/fib.pyx
+++ b/fib.pyx
@@ -1,8 +1,3 @@
-# Usage:
-#   cython3 --embed -o fib.pyx.c fib.pyx
-#   g++ -O3 -o fib fib.pyx.c -I/usr/include/python3.5m/ -lpython3.5m
-#   time ./fib
-
 cdef long fib(long n):
   if n <= 1: return 1
   return fib(n - 1) + fib(n - 2)


### PR DESCRIPTION
Seems competitive with the other compiled/typed languages:

```
$ cython3 --embed -o fib.pyx.c fib.pyx
$ g++ -O3 -o fib fib.pyx.c -I/usr/include/python3.5m/ -lpython3.5m 
$ time ./fib 
2971215073

real	0m4.361s
user	0m4.357s
sys	0m0.004s
```

For reference the C version takes ~4.1s on my machine.