### PR TITLE
Faster fib-mem.go

### DIFF
--- a/fib-mem.go
+++ b/fib-mem.go
@@ -4,19 +4,27 @@ import (
 	"fmt"
 )
 
-func fib(n int, cache *[]uint64) uint64 {
-	if n >= len(*cache) {
-		a := fib(n-2, cache)
-		b := fib(n-1, cache)
-		*cache = append(*cache, a+b)
+type fibCache []uint64
+
+func (c *fibCache) fib(n int) uint64 {
+	if n >= len(*c) {
+		if n > cap(*c) {
+			if *c == nil {
+				*c = make(fibCache, 2, n)
+				(*c)[0], (*c)[1] = 1, 1
+			} else {
+				old := *c
+				*c = make(fibCache, len(old), n)
+				copy(*c, old)
+			}
+		}
+		a := c.fib(n - 2)
+		b := c.fib(n - 1)
+		*c = append(*c, a+b)
 	}
-	return (*cache)[n]
+	return (*c)[n]
 }
 
 func main() {
-	const n = 46
-	cache := make([]uint64, 2, n)
-	cache[0] = 1
-	cache[1] = 1
-	fmt.Println(fib(n, &cache))
+	fmt.Println(new(fibCache).fib(46))
 }

--- a/fib-mem.go
+++ b/fib-mem.go
@@ -4,21 +4,19 @@ import (
 	"fmt"
 )
 
-func fib(n uint64, cache []uint64) uint64 {
-	if n <= 1 {
-		return 1
+func fib(n int, cache *[]uint64) uint64 {
+	if n >= len(*cache) {
+		a := fib(n-2, cache)
+		b := fib(n-1, cache)
+		*cache = append(*cache, a+b)
 	}
-	a, b := &cache[n-1], &cache[n-2]
-	if *a == 0 {
-		*a = fib(n-1, cache)
-	}
-	if *b == 0 {
-		*b = fib(n-2, cache)
-	}
-	return *a + *b
+	return (*cache)[n]
 }
 
 func main() {
-	cache := make([]uint64, 46)
-	fmt.Println(fib(46, cache))
+	const n = 46
+	cache := make([]uint64, 2, n)
+	cache[0] = 1
+	cache[1] = 1
+	fmt.Println(fib(n, &cache))
 }


### PR DESCRIPTION
Rewrite fib-mem.go:
- faster: faster check of cache missing values
- refactor for cleaner API: encapsulate the cache in a type, so `fib` just becomes a method applied to the cache