### PR TITLE
Modified C and C++ examples to use fixed-width unsigned integers

### DIFF
--- a/fib.c
+++ b/fib.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
+#include <stdint.h>
 
-unsigned long fib(unsigned long n) {
+uint64_t fib(uint64_t n) {
   if (n <= 1) return 1;
   return fib(n - 1) + fib(n - 2);
 }

--- a/fib.cpp
+++ b/fib.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
+#include <stdint.h>
 
-long fib(long n) {
+uint64_t fib(uint64_t n) {
   if (n <= 1) return 1;
   return fib(n - 1) + fib(n - 2);
 }


### PR DESCRIPTION
Changing C++ from signed long to uint64_t resulted in a 10% performance
increase locally. Note that on some 32-bit systems long may be 32 bits,
and hence would break repo consistency unless 64-bits is specified.