### PR TITLE
Add Scheme version (with a placeholder for the timing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ NOTE: These languages include compilation time which should be taken into consid
 |----------|----------|-----------------------|
 | Ruby     |  195.601 | `time ruby fib.rb`    |
 | Php      |  206.346 | `time php fib.php`    |
-| Guile    |  ??????? | `time guile fib.scm`  |
+| Scheme   |  ??????? | `time guile fib.scm`  |
 | Python   |  502.036 | `time python fib.py`  |
 | Python3  |  758.681 | `time python3 fib.py` |
 | Perl     | 1133.131 | `time perl fib.pl`    |

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ NOTE: These languages include compilation time which should be taken into consid
 |----------|----------|-----------------------|
 | Ruby     |  195.601 | `time ruby fib.rb`    |
 | Php      |  206.346 | `time php fib.php`    |
+| Guile    |  ??????? | `time guile fib.scm`  |
 | Python   |  502.036 | `time python fib.py`  |
 | Python3  |  758.681 | `time python3 fib.py` |
 | Perl     | 1133.131 | `time perl fib.pl`    |

--- a/fib.scm
+++ b/fib.scm
@@ -1,0 +1,7 @@
+(define (fib n)
+  (if (<= n 1) 1
+      (+ (fib (- n 1))
+	 (fib (- n 2)))))
+
+(display (fib 46))
+(newline)


### PR DESCRIPTION
My times with different Scheme implementations are:
- Guile 2.2.2: 7m55s
- Guile 3.0 (from git): 3m20s
- Racket: 2m8s

For comparison: 
- Python3: 25m