### PR TITLE
Added trivial memoization optimization for Perl5.

### DIFF
--- a/fib-mem.pl
+++ b/fib-mem.pl
@@ -1,0 +1,10 @@
+use Memoize;
+memoize('fib');
+sub fib {
+  my $n = shift;
+  if ( $n <= 1 ) { return 1; }
+  return fib($n - 1) + fib($n - 2);
+}
+      
+print fib(46)
+      


### PR DESCRIPTION
Given how slow the initial perl example was, I did the obvious optimization and turned on memoization.

```
joe@gandalf:~/play/fib$ time perl fib-mem.pl 
2971215073
real	0m0.008s
user	0m0.007s
sys	0m0.000s
```
