### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ so are not a good apples to apples comparisons. It demonstrates that all benchma
 | Nim (mem)               |  0.006*  | `nim cpp -d:release fib_mem.nim`     | `time ./fib_mem`            |
 | C++ (constexpr)         |  0.086*  | `g++-8 -O3 -o fib fib-constexpr.cpp` | `time ./fib`                |
 | Node (mem)              |  0.112*  |                                      | `time node fib-mem.js`      |
-| Python (lru_cache)      |  TODO    |                                      | `time python3 fib-cache.pu` |
+| Python (lru_cache)      |  TODO    |                                      | `time python3 fib-cache.py` |
 | Lua (mem)               |  TODO    |                                      | `time luajit fib-mem.lua`   |
 
 **NOTE:**


### PR DESCRIPTION
`time python3 fib-cache.pu` changed to `time python3 fib-cache.py`.