### PR TITLE
Mark C/C++ fib functions static, use C++ headers

### DIFF
--- a/fib.c
+++ b/fib.c
@@ -1,12 +1,12 @@
 #include <stdio.h>
 #include <stdint.h>
 
-uint64_t fib(uint64_t n) {
+static uint64_t fib(uint64_t n) {
   if (n <= 1) return 1;
   return fib(n - 1) + fib(n - 2);
 }
 
 int main(void) {
-  printf("%lld \n", fib(46));
+  printf("%llu \n", fib(46));
   return 0;
 }

--- a/fib.cpp
+++ b/fib.cpp
@@ -1,11 +1,11 @@
-#include <stdio.h>
-#include <stdint.h>
+#include <cstdio>
+#include <cstdint>
 
-uint64_t fib(uint64_t n) {
+static uint64_t fib(uint64_t n) {
   if (n <= 1) return 1;
   return fib(n - 1) + fib(n - 2);
 }
 
 int main() {
-  printf("%lld \n", fib(46));
+  printf("%llu \n", fib(46));
 }


### PR DESCRIPTION
- Mark C/C++ fib functions static
- Use C++ headers, code style, no impact on performance
- Print as unsigned integers

I also want to add an important optimization, would you accept changing:
```
static uint64_t fib(uint64_t n) {
  if (n <= 1) return 1;
  return fib(n - 1) + fib(n - 2);
}
```
to
```
static uint64_t fib(uint64_t n) {
  if (n >> 63) __builtin_unreachable();
  if (n <= 1) return 1;
  return fib(n - 1) + fib(n - 2);
}
```
It's GCC and Clang compatible.