### PR TITLE
Add a Clojure(script) version

### DIFF
--- a/fib.cljc
+++ b/fib.cljc
@@ -1,0 +1,6 @@
+(defn fib [n]
+  (if (<= n 1) 1
+      (+ (fib (- n 1))
+         (fib (- n 2)))))
+
+(println (fib 46))


### PR DESCRIPTION
This is a Clojure version as specified on the project. 
It differs from #66 because it uses a non-memoized double recursive call. 
You can run the script with `clojure fib.cljc`. I guess it goes under interpreted, dynamically typed section. 

On my machine it takes ~32s. 

In fact it is also valid Clojurescript code. You can run it using `lumo` or `planck` and it will run as javascript. Main difference between lumo and planck is that lumo is running on Node.js and javascript V8 engine whereas planck runs on JavaScriptCore. 
`lumo fib.cljc`
`planck fib.cljc`

Installing `clojure`: [https://clojure.org/guides/getting_started](https://clojure.org/guides/getting_started) 
Installing `lumo`: [https://github.com/anmonteiro/lumo](https://github.com/anmonteiro/lumo)
Installing `planck`: [http://planck-repl.org/setup.html](http://planck-repl.org/setup.html) 

PS: I think it is also a valid [Pixie](https://github.com/pixie-lang/pixie) code, which is a clojure-inspired lisp lang running on python. But I didn't tested it. 