### PR TITLE
Add Powershell (Core) version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ optimized/fib-local
 optimized/fib_const
 optimized/main
 optimized/main.dSYM/
+.vscode/

--- a/fib.ps1
+++ b/fib.ps1
@@ -6,7 +6,6 @@ function fib {
     }
     $a = fib($num - 1)
     $a += fib($num - 2)
-    Write-Host $a
     $a
 }
 fib(46);

--- a/fib.ps1
+++ b/fib.ps1
@@ -1,0 +1,12 @@
+function fib {
+    param($num)
+    if ($num -le 1) {
+        1
+        return
+    }
+    $a = fib($num - 1)
+    $a += fib($num - 2)
+    Write-Host $a
+    $a
+}
+fib(46);

--- a/optimized/fib_mem.ps1
+++ b/optimized/fib_mem.ps1
@@ -1,0 +1,13 @@
+$cache = New-Object System.Int64[] 47
+function fib {
+    param($num)
+    if ($cache[$num] -eq 0) {
+        $a = fib($num - 2)
+        $b = fib($num - 1)
+        $cache[$num] = $a+$b
+    }
+    $cache[$num]
+}
+$cache[0] = 1
+$cache[1] = 1
+fib(46)


### PR DESCRIPTION
This adds a version for Windows PowerShell or PowerShell Core on Linux/OSX. Running with `pwsh ./fib.ps1` for Linux/OSX, or `powershell ./fib.ps1` for Windows. Because the runtime is almost proportional with the resulted number, I calculated that running this script would need about 224 hours or about 9 days. The optimized memory function needs about 0.5 seconds.