### PR TITLE
Added memoized tcl.

### DIFF
--- a/optimized/fib-mem.tcl
+++ b/optimized/fib-mem.tcl
@@ -1,0 +1,36 @@
+set ::memoized [dict create]
+
+proc memoize {} {
+		
+	if {[info level] > 2 && [info level -2] == "memoize"} {
+		# Memoizing a new value. Let the calling proc run normally.
+		return
+	}
+
+	# Get the proc and args of the calling proc.
+	set cmd [info level -1]
+
+	if {[dict exists $::memoized $cmd]} {
+
+		# Get value from cache
+		set val [dict get $::memoized $cmd]
+	} else {
+
+		# Run the command again and cache result.
+		set val [{*}$cmd]
+		dict set ::memoized $cmd $val
+	}
+
+	# Tell the calling proc to return cached value.
+	return -level 2 $val
+}
+
+proc fib {n} {
+    memoize
+    if {$n <= 1} {
+        return 1
+    }
+    return [expr {[fib [expr {$n - 1}]] + [fib [expr {$n - 2}]]}]
+}
+
+puts [fib 46]

--- a/optimized/run.sh
+++ b/optimized/run.sh
@@ -35,6 +35,7 @@ languages << Language.new("Perl Memoized 2", :optimized, "", "time perl fib-mem2
 languages << Language.new("Perl Inline", :optimized, "", "time perl fib-inline.py")
 languages << Language.new("Ruby Memoized", :optimized, "", "time ruby fib-mem.rb")
 languages << Language.new("Swift Memoized", :optimized, "swiftc -O -g fib-mem.swift", "time ./fib-mem")
+languages << Language.new("Tcl Memoized", :optimized, "", "time tclsh fib-mem.tcl")
 languages << Language.new("Erlang Memoized", :optimized, "erlc +native +'{hipe,[o3]}' fib_mem.erl", "time erl -noinput -noshell -s fib_mem")
 languages << Language.new("Escript Memoized", :optimized, "", "time escript fib_mem.es")
 languages << Language.new("Haskell Memoized", :optimized, "ghc -O3 -o fib_mem fib_mem.hs", "time ./fib_mem")


### PR DESCRIPTION
The native fib.tcl doesn't finish. I've added a memoizer that makes the same proc finish in less than a second. The proc is nearly identical with the only difference being "memoize" on the first line.