### PR TITLE
Faster / more idiomatic Pascal version

### DIFF
--- a/fib.pas
+++ b/fib.pas
@@ -1,6 +1,9 @@
 program Fib;
 
+// Allows for `Result` instead of the function name.
 {$mode ObjFPC}
+// Disables "IO checking" for `WriteLn`.
+{$I-}
 
 function Fib(const N: UInt64): UInt64; inline;
 begin

--- a/fib.pas
+++ b/fib.pas
@@ -1,11 +1,15 @@
 program Fib;
-function fib(n: int64): int64;
+
+{$mode ObjFPC}
+
+function Fib(const N: UInt64): UInt64; inline;
 begin
-	if n > 1 then
-		fib := (fib(n-1) + fib(n-2))
-	else
-		fib := 1;
+  case N of
+    0, 1: Result := 1;
+    otherwise Result := Fib(N - 1) + Fib(N - 2);
+  end;
 end;
+
 begin
-    writeln(fib(46))
+  WriteLn(Fib(46));
 end.

--- a/run.sh
+++ b/run.sh
@@ -36,7 +36,7 @@ languages << Language.new("Crystal", :compiled, "crystal build --release fib.cr"
 languages << Language.new("Swift", :compiled, "swiftc -O -g fib.swift", "./fib")
 languages << Language.new("Kotlin/Native", :vm, "kotlinc-native Fib.kt -o Fib", "./Fib.kexe")
 languages << Language.new("OCaml", :compiled, "ocamlopt -O3 -o fib fib.ml", "./fib")
-languages << Language.new("Pascal", :compiled, "fpc -O3 ./fib.pas", "./fib")
+languages << Language.new("Pascal", :compiled, "fpc -O3 -Si ./fib.pas", "./fib")
 languages << Language.new("Go", :compiled, "go build fib.go", "./fib")
 languages << Language.new("Lisp", :compiled, "sbcl --load fib.lisp", "./fib")
 languages << Language.new("Haskell", :compiled, "rm ./fib.o && ghc -O3 -o fib fib.hs", "./fib")


### PR DESCRIPTION
This uses `case of` instead of an if statement (which tends to generate better code in many scenarios) and also changes the input type from `Int64` to `UInt64` so as to be closer to most of the other programs.