### PR TITLE
Disable overflow checks in Pony

### DIFF
--- a/fib.pony
+++ b/fib.pony
@@ -3,7 +3,7 @@ actor Main
     if n <= 1 then
       1
     else
-      fib(n - 1) + fib(n - 2)
+      fib(n -~ 1) + fib(n -~ 2)
     end
 
   new create(env: Env) =>


### PR DESCRIPTION
Disabling overflow checks (aka. using unsafe arithmetic) dropped the runtime from 5.2 to 4.4 on my system.
I would consider this change obvious, since unsafe arithmetic is introduced in the Pony language tutorial, right after explaining checked arithmetic on https://tutorial.ponylang.io/expressions/arithmetic.html
Swift also uses unsafe arithmetic.