### PR TITLE
chore: bump Ubuntu to 20.04 & OCaml to 4.11.1

### DIFF
--- a/run.rb
+++ b/run.rb
@@ -1,5 +1,3 @@
-#!/usr/bin/env ruby
-
 class Language
   attr_accessor :name, :type, :compile_cmd, :run_cmd, :compile_time, :run_time
   def initialize(name, type, compile_cmd, run_cmd)


### PR DESCRIPTION
I wanted to pull in a newer version of OCaml for which I needed version > 2 of opam which meant bumping Ubuntu. Bumping Ubuntu in turn led to a few breakages but with the changes in this PR `docker build` runs until completion on my local machine.