### PR TITLE
Add a pypy benchmark

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
             tcl \
             guile-2.2 \
             luajit \
-            gnat
+            gnat \
+            pypy3
 
 # OCaml
 RUN opam init --auto-setup --disable-sandboxing --dot-profile ~/.bashrc --compiler 4.11.1+flambda

--- a/run.rb
+++ b/run.rb
@@ -54,6 +54,7 @@ languages << Language.new("Lua Jit", :mixed, "", "luajit fib.lua")
 languages << Language.new("Node", :mixed, "", "node fib.js")
 languages << Language.new("Elixir", :mixed, "", "ERL_COMPILER_OPTIONS='[native,{hipe, [o3]}]' && elixir fib.exs")
 languages << Language.new("Clojure", :mixed, "", "clojure fib.cljc")
+languages << Language.new("Python3 (PyPy)", :mixed, "", "pypy3 fib.py")
 
 languages << Language.new("Php", :interpreted, "", "php fib.php")
 languages << Language.new("Scheme", :interpreted, "", "guile fib.scm")


### PR DESCRIPTION
This PR adds pypy to the list of benchmarks, as described in #125. Closes #125.