### PR TITLE
Fix Crystal version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ puts fib(46)
 Here is the Crystal version:
 ```
 def fib(n : UInt64)
-  return 1 if n <= 1
+  return 1_u64 if n <= 1
   fib(n - 1) + fib(n - 2)
 end
 


### PR DESCRIPTION
Gives `Unhandled exception: Arithmetic overflow (OverflowError)` without this change.

And if `&-` and `&+` are also used instead of `-` and `+` it will  give an incorrect result `-1323752223` without this change.