### PR TITLE
Speed up Crystal version

### DIFF
--- a/fib.cr
+++ b/fib.cr
@@ -1,4 +1,4 @@
-def fib(n : UInt64)
+def fib(n)
   return 1_u64 if n <= 1
   fib(n &- 1) &+ fib(n &- 2)
 end


### PR DESCRIPTION
This gives about `20% ` speedup for me when calculating `fib(46)`.

MacOS 10.15.7
Crystal 1.2.2
Intel(R) Core(TM) i7-3615QM CPU @ 2.30GHz