### PR TITLE
Update swift optimization flag

### DIFF
--- a/fib.swift
+++ b/fib.swift
@@ -1,6 +1,11 @@
-func fib(n: Int) -> Int {
-  if n <= 1 { return n }
-  return fib(n: n - 1) + fib(n: n - 2)
+@main
+struct Main {
+    static func fib(_ n: Int) -> Int {
+        if n <= 1 { return n }
+        return fib(n - 1) + fib(n - 2)
+    }
+    
+    static func main() {
+        print(fib(47))
+    }
 }
-
-print(fib(n: 47))

--- a/optimized/fib-mem.swift
+++ b/optimized/fib-mem.swift
@@ -1,13 +1,21 @@
-func fib(n: Int, cache: inout [Int]) -> Int {
-    if n <= 1 { return 1 }
-    if cache[n-1] == 0 {
-        cache[n-1] = fib(n: n-1, cache: &cache)
+@main
+struct Main {
+    static func fib(_ n: Int, _ cache: inout [Int]) -> Int {
+        if n <= 1 { return n }
+        
+        if cache[n - 1] == 0 {
+            cache[n - 1] = fib(n - 1, &cache)
+        }
+        
+        if cache[n - 2] == 0 {
+            cache[n - 2] = fib(n - 2, &cache)
+        }
+        
+        return cache[n - 1] + cache[n - 2]
     }
-    if cache[n-2] == 0 {
-        cache[n-2] = fib(n: n-2, cache: &cache)
+    
+    static func main() {
+        var cache = Array.init(repeating: 0, count: 46)
+        print(fib(46, &cache))
     }
-    return cache[n-1] + cache[n-2]
 }
-
-var cache = Array.init(repeating: 0, count: 46)
-print(fib(n: 46, cache: &cache))

--- a/run.sh
+++ b/run.sh
@@ -59,7 +59,7 @@ languages << Language.new("ml", "OCaml", :compiled, "ocamlopt -O3 -o fib fib.ml"
 languages << Language.new("pas", "Pascal", :compiled, "fpc -O3 -Si ./fib.pas", "./fib")
 languages << Language.new("pony", "Pony", :compiled, "ponyc -s -b fib -p ./fib.pony", "./fib")
 languages << Language.new("rs", "Rust", :compiled, "rustc -C opt-level=3 fib.rs", "./fib")
-languages << Language.new("swift", "Swift", :compiled, "swiftc -Ounchecked -g fib.swift", "./fib")
+languages << Language.new("swift", "Swift", :compiled, "swiftc -Ounchecked -parse-as-library fib.swift", "./fib")
 languages << Language.new("v", "V", :compiled, "v -prod -o fib fib.v", "./fib")
 languages << Language.new("cbl", "Cobol", :compiled, "cobc -x -O3 -o fib ./fib.cbl", "./fib")
 #languages << Language.new("qb64", "QB64", :compiled, "qb64 -x $(pwd)/fib.bas -o $(pwd)/fib", "./fib")

--- a/run.sh
+++ b/run.sh
@@ -59,7 +59,7 @@ languages << Language.new("ml", "OCaml", :compiled, "ocamlopt -O3 -o fib fib.ml"
 languages << Language.new("pas", "Pascal", :compiled, "fpc -O3 -Si ./fib.pas", "./fib")
 languages << Language.new("pony", "Pony", :compiled, "ponyc -s -b fib -p ./fib.pony", "./fib")
 languages << Language.new("rs", "Rust", :compiled, "rustc -C opt-level=3 fib.rs", "./fib")
-languages << Language.new("swift", "Swift", :compiled, "swiftc -O -g fib.swift", "./fib")
+languages << Language.new("swift", "Swift", :compiled, "swiftc -Ounchecked -g fib.swift", "./fib")
 languages << Language.new("v", "V", :compiled, "v -prod -o fib fib.v", "./fib")
 languages << Language.new("cbl", "Cobol", :compiled, "cobc -x -O3 -o fib ./fib.cbl", "./fib")
 #languages << Language.new("qb64", "QB64", :compiled, "qb64 -x $(pwd)/fib.bas -o $(pwd)/fib", "./fib")


### PR DESCRIPTION
The rust and c/c++ compilers omit runtime safety checks when optimized with level 3, but for some reason someone picked ``-O`` for the swift version which does *not* omit runtime safety checks, and hence multitudes slower than the rust and c/c++ counterparts. I've changed the flag to ``-Ounchecked`` which is more equivalent to the rust and c/c++ optimizations, which gained circa +30% performance.

Ideally, you wouldn't use global code (the ``-g`` flag) for this either, you'd want a static main and pass ``-parse-as-library`` to the compiler, but i couldn't notice any performance difference for this trivial fib example, hence i left that out.